### PR TITLE
use cabal data-files section for data

### DIFF
--- a/pomodoro.cabal
+++ b/pomodoro.cabal
@@ -11,6 +11,10 @@ maintainer:          Al Zohali <zohl@fmap.me>
 category:            Office
 build-type:          Simple
 cabal-version:       >=1.10
+data-files: res/Bell.mp3
+          , res/Inactive.png
+          , res/Relax.png
+          , res/Work.png
 
 
 source-repository head


### PR DESCRIPTION
instead of trying to guess where the .png/.mp3 are, we use that cabal
facility. This has some gotchas as the media is only correctly placed on
cabal install (preferably on sandbox) not cabal build. So this last one
only work for typechecking.

But we gain on to correctly placing data on installs!