### PR TITLE
take as parameters the mp3 player

### DIFF
--- a/src/GUI.hs
+++ b/src/GUI.hs
@@ -61,19 +61,17 @@ showPopup summary' body' = display_ $
   <> (timeout $ Custom 8) 
 
 
-playSound :: String -> IO ()
-playSound sound = findExecutable "mpg321" >>= maybe
-  (putStrLn "cannot find mpg321")
-  (\player -> spawnProcess player [sound] >> return ())
-  
+playSound :: String -> String -> IO ()
+playSound player sound = findExecutable player >>= maybe
+     (putStrLn "cannot find soundProgram")
+     (\player -> spawnProcess player [sound] >> return ())
+
 
 runGUI :: Settings -> GUICallbacks -> IO () 
 runGUI settings cbs = start $ initGUI where
 
   initGUI :: IO ()
   initGUI = do
-    base <- getDataDir
-
     res  <- initResources
     tbi  <- taskBarIconCreate
 
@@ -81,11 +79,12 @@ runGUI settings cbs = start $ initGUI where
 
     (dialogFrame, withNameDialog) <- initNameDialog
     evtHandlerOnTaskBarIconEvent tbi (onTaskBarEvt tbi dialogFrame withNameDialog)
-    
+
+    bell <- getDataFileName "res/Bell.mp3"
     onInit cbs $ GUICallforths {
         iconUpdate        = setIcon res tbi
       , popupNotification = showPopup
-      , soundNotification = playSound (base++"/Bell.mp3")
+      , soundNotification = playSound (soundProgram settings) bell
     }
 
 

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -33,6 +33,10 @@ data Settings = Settings {
   , askPomodoroName     :: Bool
     -- ^ If True, will ask a name for a new interval 
     -- (this will not affect command line interface).
+
+  , soundProgram        :: String
+    -- ^ Name of the program that will play the "bell" sound on each
+    -- pomodoro, defaults to mpg321.
   } deriving (Eq)
 
 
@@ -47,6 +51,7 @@ defaultSettings = Settings {
   , enablePopups        = True
   , enableSounds        = False
   , askPomodoroName     = False
+  , soundProgram        = "mpg321"
   }
 
 
@@ -61,6 +66,7 @@ instance Show Settings where
     , formatField "enablePopups"        enablePopups
     , formatField "enableSounds"        enableSounds
     , formatField "askPomodoroName"     askPomodoroName
+    , formatField "soundProgram"        soundProgram
     ] where
         formatField :: (Show a) => String -> (Settings -> a) -> String
         formatField key value = key ++ " = " ++ (show $ value settings)
@@ -90,6 +96,7 @@ parseSettings defaults contents = foldl parseLine defaults configLines where
       "enablePopups"        -> defaults' { enablePopups        = (read value :: Bool) }
       "enableSounds"        -> defaults' { enableSounds        = (read value :: Bool) }
       "askPomodoroName"     -> defaults' { askPomodoroName     = (read value :: Bool) }
+      "soundProgram"        -> defaults' { soundProgram        = (read value :: String) }
       _                     -> defaults'
 
 


### PR DESCRIPTION
mpg321 will still be the default (per config generation), but we allow to specify in the `soundProgram` field others as mplayer. This help because as cabal can request a specific program installed on the system, user will have to thinker a little bit for make pomodoro work